### PR TITLE
dunder field lookups for reverse 1-to-1 relationship: drop _set suffix

### DIFF
--- a/iommi/from_model.py
+++ b/iommi/from_model.py
@@ -11,6 +11,7 @@ from django.db.models import (
     Field as DjangoField,
     ManyToManyRel,
     ManyToOneRel,
+    OneToOneRel,
     Model,
 )
 from iommi.struct import Struct
@@ -178,6 +179,8 @@ def get_field_name(field: DjangoField) -> str:
             return field.related_name
         elif field.related_name == '+':
             return None
+        elif isinstance(field, OneToOneRel):
+            return field.name
         else:
             return f'{field.name}_set'
     else:

--- a/iommi/query__tests.py
+++ b/iommi/query__tests.py
@@ -617,7 +617,7 @@ def test_from_model_with_model_class():
         'foo',
         'bars',
         'fieldfrommodelforeignkeytest_set',
-        'fieldfrommodelonetoonetest_set',
+        'fieldfrommodelonetoonetest',
         'createoreditobjecttest_set',
     }
     assert list(t.filters.keys()) == ['foo']
@@ -631,7 +631,7 @@ def test_from_model_with_queryset():
         'foo',
         'bars',
         'fieldfrommodelforeignkeytest_set',
-        'fieldfrommodelonetoonetest_set',
+        'fieldfrommodelonetoonetest',
         'createoreditobjecttest_set',
     }
     assert list(t.filters.keys()) == ['foo']

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -86,6 +86,8 @@ from tests.models import (
     ChoicesModel,
     CSVExportTestModel,
     DefaultsInForms,
+    Foo,
+    FieldFromModelOneToOneTest,
     FromModelWithInheritanceTest,
     QueryFromIndexesTestModel,
     SortKeyOnForeignKeyB,
@@ -3516,6 +3518,21 @@ def test_auto_model_dunder_path():
 
     assert 'bar_foo' in keys(table.columns)
     table.__html__()
+
+
+@pytest.mark.django_db
+def test_auto_model_dunder_path_1to1_reverse():
+    foo = Foo.objects.create(foo=1)
+    FieldFromModelOneToOneTest.objects.create(foo_one_to_one=foo, f_char="dunder_1to1")
+    assert foo.fieldfrommodelonetoonetest.f_char == "dunder_1to1"
+    table = Table(
+        auto__model=Foo,
+        auto__include=[
+            "foo",
+            "fieldfrommodelonetoonetest__f_char",
+        ]
+    ).bind(request=req('get'))
+    assert "fieldfrommodelonetoonetest_f_char" in keys(table.columns)
 
 
 @pytest.mark.django_db

--- a/tests/models.py
+++ b/tests/models.py
@@ -42,6 +42,7 @@ class FieldFromModelForeignKeyTest(Model):
 
 class FieldFromModelOneToOneTest(Model):
     foo_one_to_one = OneToOneField(Foo, on_delete=CASCADE)
+    f_char = CharField(max_length=255, blank=True)
 
 
 class ExpandModelTestA(Model):


### PR DESCRIPTION
Fixes a regression introduced in 5.8.0.

Given an example:

```python3
class Parent(Model):
    name = CharField(max_length=255)

class Child(Model):
    parent = OneToOneField(Parent, on_delete=CASCADE)
    myfield = CharField(max_length=255)
```

Before 5.8.0, the dunder path to access the `Child.myfield` from `Parent` in a Table was consistent with Django's behavior (`Parent.child` contains the corresponding `Child` instance):

```python3
Table(auto__model=Parent, auto__include=["name", "child__myfield"])
```

Since 5.8.0, the above table raises an AssertioError `You can only include fields that exist on the model`. In 5.8.0, the dunder path to the field changed to `child_set__myfield`, which is inconsistent with how the object is accessed on the model class in Django.

This commit brings back the pre-5.8 dunder path for one-to-one reverse lookups.