### PR TITLE
Fix over-optimized Struct semantics

### DIFF
--- a/iommi/struct.py
+++ b/iommi/struct.py
@@ -33,9 +33,12 @@ class Struct(dict):
 
     __str__ = __repr__
 
-    __getattribute__ = dict.__getitem__
-
-    __missing__ = object.__getattribute__
+    def __getattribute__(self, item):
+        try:
+            return dict.__getitem__(self, item)
+        except KeyError:
+            pass
+        return object.__getattribute__(self, item)
 
     __setattr__ = dict.__setitem__
 

--- a/iommi/struct__tests.py
+++ b/iommi/struct__tests.py
@@ -34,6 +34,13 @@ def test_get_item():
     assert 1 == s.get('a')
 
 
+def test_get_item_missing_key():
+    with pytest.raises(KeyError) as e:
+        _ = Struct()['a']
+    assert isinstance(e.value, KeyError)
+    assert e.value.args == ('a',)
+
+
 def test_get_attr_broken_shadow():
     # This is mostly to document the somewhat quirky behavior when shadowing __getitem__
     class MyStruct(Struct):


### PR DESCRIPTION
Item access should have dict behavior on missing keys
