### PR TITLE
Escape function name in profiler

### DIFF
--- a/iommi/profiling.py
+++ b/iommi/profiling.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from django.http import StreamingHttpResponse
+from django.utils.html import escape
 
 from iommi._web_compat import (
     HttpResponse,
@@ -127,7 +128,12 @@ class HTMLStats(pstats.Stats):
             print('<td></td>', file=self.stream)
         else:
             print(f'<td class="numeric">{f8(ct/cc)}</td>', file=self.stream)
-        print(f'<td><a href="{src_debug_url_builder(path, line_number)}">{function_name}</a></td>', file=self.stream)
+        
+        if line_number and path:
+            print(f'<td><a href="{src_debug_url_builder(path, line_number)}">{escape(function_name)}</a></td>', file=self.stream)
+        else:
+            print(f'<td>{escape(function_name)}</td>', file=self.stream)
+
         print(f'<td>{nice_path}</td>', file=self.stream)
         print(f'<td class="numeric">{line_number}</td>', file=self.stream)
         print(f'</tr>', file=self.stream)


### PR DESCRIPTION
function_name can be formatted as `<built-in method builtins.len>`, so it needs to be escaped; otherwise, the function name won't display at all in the resulting HTML. For extra clarity, function name is only rendered as a link if it's associated with a path and line number.

Before image:

<img width="1009" alt="Skärmavbild 2024-01-16 kl  09 57 15" src="https://github.com/iommirocks/iommi/assets/10375407/8769c8c9-be75-4ba3-a683-0b4650d3c0e1">



After image:
<img width="1246" alt="Skärmavbild 2024-01-16 kl  09 55 45" src="https://github.com/iommirocks/iommi/assets/10375407/dd7c7112-f342-4be4-b3dc-0d93652ce3bd">
