### PR TITLE
WIP actions should be replaced on ajax

### DIFF
--- a/iommi/static/js/iommi.js
+++ b/iommi/static/js/iommi.js
@@ -200,10 +200,8 @@ class IommiBase {
         const ajaxOptions = {signal: this.resetAbortController(container).signal};
 
         try {
-            const {html} = await this.fetchJson(ajaxURL, ajaxOptions);
+            const {html, actions} = await this.fetchJson(ajaxURL, ajaxOptions);
 
-            // We have to remove each child before setting innerHTML since disconnectedCallback
-            // is not fired on the children using IE11
             let child = container.firstElementChild;
             while (child) {
                 container.removeChild(child);
@@ -212,6 +210,10 @@ class IommiBase {
 
             const element = document.createRange().createContextualFragment(html);
             container.appendChild(element);
+
+            let actions_container = container.parentElement.querySelector('.iommi-actions');
+            const actions_element = document.createRange().createContextualFragment(actions);
+            actions_container.replaceWith(actions_element);
 
             container.dispatchEvent(
                 new CustomEvent('iommi.element.populated', {

--- a/iommi/style_base.py
+++ b/iommi/style_base.py
@@ -153,6 +153,7 @@ base = Style(
     Actions=dict(
         tag='div',
         attrs__class__links=True,
+        attrs__class={'iommi-actions': True},
     ),
     MenuItem=dict(
         a__tag='a',

--- a/iommi/table.py
+++ b/iommi/table.py
@@ -1779,7 +1779,8 @@ class Table(Part, Tag):
             return {
                 'html': table.container.__html__(
                     render=lambda fragment, context: fragment.render_text_or_children(context=context)
-                )
+                ),
+                'actions': table.outer.children.actions.__html__(),
             }
 
         endpoints__csv__func = endpoint__csv


### PR DESCRIPTION
After a discussion on Discord: the actions needs to be reloaded to get filters included in CSV download button.

Bery: hmm, you'll probably need data-iommi-id-of-table like the filter has, so you know which actions to replace