### PR TITLE
Fix bulk 'all items on all pages' with multiple tables

### DIFF
--- a/iommi/table.py
+++ b/iommi/table.py
@@ -2464,8 +2464,7 @@ class Table(Part, Tag):
     def _selection_identifiers(self, prefix):
         """Return a list of identifiers of the selected rows. Or 'all' if all
         sorted_and_filtered_rows are selected."""
-        # TODO: this needs to be namespaced
-        if self.get_request().POST.get('_all_pks_') == '1':
+        if '_all_pks_' in self.bulk.fields and self.get_request().POST.get(self.bulk.fields._all_pks_.iommi_path) == '1':
             return 'all'
         else:
             return [key[len(prefix) :] for key in self.get_request().POST if key.startswith(prefix)]


### PR DESCRIPTION
Currently when selecting all items on all pages is and running a bulk action it only works if that table is the first table in an iommi page. If its the second table it will silently ignore the instruction and just do it on the items you actually selected.