### PR TITLE
Transient `Cell` refactor

### DIFF
--- a/iommi/edit_table.py
+++ b/iommi/edit_table.py
@@ -131,7 +131,7 @@ class EditCells(Cells):
             field = self.get_field(column)
             if not field:
                 continue
-            yield self.cell_class(cells=self, column=column)
+            yield self.cell_class(cells=self, column=column, parent=self)
 
 
 class EditColumn(Column):


### PR DESCRIPTION
This would remove styling from `Cell`, but it's quite a bit faster.  At Dryft I have a (admittedly way too big) page that goes from ~4s to ~3.6s with this change.