### PR TITLE
support overriding model_object.save() to be able to pass kwargs

### DIFF
--- a/docs/test_doc_forms.py
+++ b/docs/test_doc_forms.py
@@ -319,6 +319,7 @@ def test_customization_of_save_behavior():
     The callbacks are executed in this order:
 
     - `extra__new_instance`: This is called to create a new instance of the model. By default it just calls `form.model()`.
+    - `extra__save`: This is called to save each model_object. By default it calls `model_object.save()`.
     - `extra__pre_save_all_but_related_fields` (only called for `Form.create`)
     - `extra__on_save_all_but_related_fields` (only called for `Form.create`)
     - `extra__pre_save` (before `instance.save()`)

--- a/docs/test_doc_forms.py
+++ b/docs/test_doc_forms.py
@@ -325,6 +325,28 @@ def test_customization_of_save_behavior():
     - `extra__pre_save` (before `instance.save()`)
     - `extra__on_save` (after `instance.save()`)
 
+    **IMPORTANT**: Be careful when using `extra__save`!
+
+    #. the passed kwarg for object instance, which we need to save is `model_object` *and not instance*!
+    #. always test the instance of `model_object` to avoid possible bugs! Because quite often you need to edit objects from multiple models, for example:
+    """
+
+    class AlbumForm(Form):
+        class Meta:
+            auto__model = Album
+            auto__include = ["name", "artist__name"]
+
+            @classmethod
+            def extra__save(model_object, **_):
+                if isinstance(model_object, Album):
+                    # IMPORTANT: always test the proper model when overriding save
+                    model_object.save(foo="bar")
+                else:
+                    # because this gets called for saving the artist.name
+                    model_object.save()
+
+    # language=rst
+    """
     After a POST is completed, the `extra__redirect` callback is executed if present, otherwise `extra__redirect_to`
     is used to determine where to redirect to.
     """

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -259,7 +259,7 @@ def create_or_edit_object__post_handler(*, form, is_create=None, **_):
 
         # two phase save for creation in django...
         form.invoke_callback(form.extra.pre_save_all_but_related_fields)
-        form.instance.save()
+        form.invoke_callback(form.extra.save, model_object=form.instance)
         form.invoke_callback(form.extra.on_save_all_but_related_fields)
 
     form.apply(form.instance)
@@ -279,7 +279,7 @@ def create_or_edit_object__post_handler(*, form, is_create=None, **_):
         model_object = form.instance
         if prefix:  # Might be ''
             model_object = getattr_path(model_object, prefix)
-        model_object.save()
+        form.invoke_callback(form.extra.save, model_object=model_object)
     form.invoke_callback(form.extra.on_save)
 
     return create_or_edit_object_redirect(is_create, form.extra.redirect_to, form.extra.redirect, form)
@@ -1709,6 +1709,7 @@ class Form(Part, Tag):
         actions_template='iommi/form/actions.html',
         attr=MISSING,
         fields_template=None,
+        extra__save=lambda model_object, **_: model_object.save(),
     )
     def __init__(self, **kwargs):
         super(Form, self).__init__(

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2991,7 +2991,7 @@ def test_custom_save():
         ),
     ).render_to_response()
 
-    instance = CreateOrEditObjectTest.objects.get()
+    instance.refresh_from_db()
     assert instance is not None
     assert instance.f_bool is False
     assert instance.f_float == 0.0

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2971,7 +2971,10 @@ def test_custom_save():
     )
 
     def extra__save(model_object, **_):
-        model_object.save(update_fields=['f_int'])
+        if isinstance(model_object, CreateOrEditObjectTest):
+            model_object.save(update_fields=['f_int'])
+        else:
+            model_object.save()
 
     form = Form.edit(
         auto__instance=instance,

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2958,6 +2958,47 @@ def test_edit_object_foreign_related_attribute():
     assert instance.f_foreign_key.foo == 42
 
 
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_custom_save():
+    instance = CreateOrEditObjectTest.objects.create(
+        f_foreign_key=Foo.objects.create(
+            foo=21,
+        ),
+        f_int=0,
+        f_float=0.0,
+        f_bool=False,
+    )
+
+    def extra__save(model_object, **_):
+        model_object.save(update_fields=['f_int'])
+
+    form = Form.edit(
+        auto__instance=instance,
+        auto__include=['f_int', 'f_float', 'f_bool'],
+        extra__save=extra__save,
+    )
+
+    form.bind(
+        request=req(
+            'post',
+            **{
+                'f_int': '1',
+                'f_float': '2.3',
+                'f_bool': '1',
+                '-submit': '',
+            },
+        ),
+    ).render_to_response()
+
+    instance = CreateOrEditObjectTest.objects.get()
+    assert instance is not None
+    assert instance.f_bool is False
+    assert instance.f_float == 0.0
+    assert instance.f_int == 1
+
+
+
 def test_redirect_default_case():
     sentinel1, sentinel2, sentinel3, sentinel4 = (
         object(),


### PR DESCRIPTION
I named it `model_object`, because in `Form.own_evaluate_parameters` there is already `instance=self.instance`