### PR TITLE
EditTable new row via ajax and improved delete button

### DIFF
--- a/docs/test_doc_cookbook_edit_tables.py
+++ b/docs/test_doc_cookbook_edit_tables.py
@@ -68,3 +68,27 @@ def test_how_do_you_edit_one_to_one_in_a_table(black_sabbath):
     assert response.status_code == 302, response.content.decode()
     assert Artist.objects.get(pk=black_sabbath.pk).name == 'new name'
     # @end
+
+    # language=rst
+    """
+    .. _edit-table-delete-as-checkbox:
+
+    How to have a delete column as checkboxes?
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Just add `data-iommi-edit-table-delete-with="checkbox"`:
+    """
+
+    edit_table = EditTable(
+        auto__model=Profile,
+        auto__include=['artist__name'],
+        columns__artist_name__field__include=True,
+        columns__delete=EditColumn.delete(),
+        **{
+            'attrs__data-iommi-edit-table-delete-with': 'checkbox',
+        }
+    )
+
+    # @test
+    show_output(edit_table)
+    # @end

--- a/iommi/edit_table.py
+++ b/iommi/edit_table.py
@@ -168,23 +168,9 @@ class EditColumn(Column):
         attr=None,
         display_name=gettext_lazy('Delete'),
         cell__attrs__class__delete=True,
-        # language=js
-        assets__fancy_delete=Asset(
-            mark_safe(
-                '''
-                    $(document).ready(() => {
-                        $(document).on('click', '.edit_table_delete', (event) => {
-                            const checked = $(event.target).closest('tr').find('input')[0].checked;
-                            $(event.target).closest('tr').find('input').prop("checked", !checked);
-                            $(event.target).closest('tr')[0].style.opacity = checked ? "1.0" : "0.3";
-                            event.preventDefault();
-                            return false;
-                        });
-                    });
-                '''
-            ),
-            tag='script',
-        ),
+        **{
+            "cell__attrs__data-iommi-edit-table-delete-row-cell": True,
+        },
     )
     def delete(cls, **kwargs):
         def cell__value(row, table, cells, column, **_):
@@ -194,9 +180,21 @@ class EditColumn(Column):
                 # row_index is the visible row number
                 # See selection() for the code that does the lookup
                 row_id = cells.row_index
-            button = Action.delete(display_name=column.display_name, attrs__class__edit_table_delete=True).bind()
+            button = Action.delete(
+                display_name=column.display_name,
+                attrs__type="button",
+                attrs__accesskey=None,
+                attrs__class__edit_table_delete=True,  # deprecated  # TODO boxed/jlubcke do we need this? not used for JS anymore
+                **{
+                    "attrs__data-iommi-edit-table-delete-row-button": True,
+                },
+            ).bind()
             path = path_join(table.iommi_path, f'pk_delete_{row_id}')
-            return mark_safe(f'{button.__html__()}<input style="display: none" type="checkbox" name="{path}" />')
+            checkbox = (
+                f'<input type="checkbox" name="{path}" id="id_{path}" data-iommi-edit-table-delete-row-checkbox="" />'
+                f'<label for="id_{path}"> {column.display_name}</label>'
+            )
+            return mark_safe(f'{button.__html__()}{checkbox}')
 
         setdefaults_path(kwargs, dict(cell__value=cell__value))
         return cls(**kwargs)
@@ -362,7 +360,11 @@ class EditTable(Table):
         )
         edit_actions__add_row = Action.button(
             display_name=gettext_lazy('Add row'),
-            attrs__onclick='iommi_add_row(this); return false',
+            attrs__type="button",
+            **{
+                "attrs__data-iommi-edit-table-add-row-button": True,
+                "attrs__data-iommi-edit-table-path": lambda table, **_: table.iommi_dunder_path,
+            }
         )
         edit_form = EMPTY
         create_form = EMPTY
@@ -372,55 +374,23 @@ class EditTable(Table):
 
         attrs = {
             'data-next-virtual-pk': '-1',
+            'data-new-row-endpoint': lambda table, **_: table.endpoints.new_row.endpoint_path,
         }
 
-        # language=js
-        assets__edit_table_js = Asset.js(
-            mark_safe(
-                '''
-                    function iommi_add_row(element) {
-                        function find_for_siblings(s) {
-                            while (s) {
-                                let t = s.querySelector('table');
-                                if (t) {
-                                    return t;
-                                }
-                                s = s.previousElementSibling;
-                            }
-                            return null;
-                        }
-
-                        let table = null;
-                        while (element.tagName !== 'FORM') {
-                            element = element.parentNode;
-                            let s = find_for_siblings(element);
-                            if (s) {
-                                table = s;
-                                break;
-                            }
-                        }
-                        if (!table) {
-                            console.error('iommi: failed to find table!');
-                            return;
-                        }
-
-                        let virtual_pk = parseInt(table.getAttribute('data-next-virtual-pk'), 10);
-                        virtual_pk -= 1;
-                        virtual_pk = virtual_pk.toString();
-                        table.setAttribute('data-next-virtual-pk', virtual_pk);
-
-                        let tmp = document.createElement('table');
-                        tmp.innerHTML = table.getAttribute('data-add-template').replaceAll('#sentinel#', virtual_pk);
-                        let y = tmp.querySelector('tr');
-                        y.setAttribute('data-pk', virtual_pk)
-                        table.querySelector('tbody').appendChild(y);
-                        if (y.querySelector('.select2_enhance')) {
-                            window.iommi.select2.initAll(y);
-                        }
-                    }
-                '''
-            )
-        )
+        @staticmethod
+        def endpoints__new_row__func(table, **kwargs):
+            if table.model is not None:
+                sentinel_row = table.model(pk='#sentinel#')
+            else:
+                sentinel_row = Struct(pk='#sentinel#', **{k: '' for k in keys(table.create_form.fields)})
+            return {
+                'html': table.cells_class(
+                    row=sentinel_row,
+                    row_index=-1,
+                    is_create_template=True,
+                    **table.row.as_dict()
+                ).bind(parent=table.create_form).__html__()
+            }
 
     def on_refine_done(self):
         super(EditTable, self).on_refine_done()
@@ -517,16 +487,6 @@ class EditTable(Table):
                 self.outer.tag = None
 
         if self.create_form is not None:
-            if self.model is not None:
-                sentinel_row = self.model(pk='#sentinel#')
-            else:
-                sentinel_row = Struct(pk='#sentinel#', **{k: '' for k in keys(self.create_form.fields)})
-            self.attrs['data-add-template'] = (
-                self.cells_class(row=sentinel_row, row_index=-1, is_create_template=True, **self.row.as_dict())
-                .bind(parent=self.create_form)
-                .__html__()
-            )
-
             # Set next virtual PK to avoid conflicts with existing virtual rows
             virtual_pks = self._get_virtual_pks_from_post()
             if virtual_pks:

--- a/iommi/edit_table__tests.py
+++ b/iommi/edit_table__tests.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from docs.models import (
@@ -61,8 +62,7 @@ def test_edit_table_rendering():
         expected_html="""
             <form action="" enctype="multipart/form-data" method="post">
                 <div class="iommi-table-plus-paginator">
-                    <table class="table" data-add-template=\'&lt;tr data-pk="#sentinel#"&gt;&lt;td&gt;&lt;input id="id_editable_thing__#sentinel#" name="editable_thing/#sentinel#" type="text" value=""&gt;&lt;/td&gt;
-&lt;td&gt;&lt;/td&gt;&lt;/tr&gt;\' data-next-virtual-pk="-1">
+                    <table class="table" data-new-row-endpoint="/new_row" data-next-virtual-pk="-1">
                         <thead>
                             <tr>
                                 <th class="first_column subheader"> Editable thing </th>
@@ -83,7 +83,7 @@ def test_edit_table_rendering():
                 </div>
                 <div class="links">
                     <button accesskey="s" name="-save"> Save </button>
-                    <button onclick="iommi_add_row(this); return false"> Add row </button>
+                    <button data-iommi-edit-table-add-row-button="" data-iommi-edit-table-path="" type="button"> Add row </button>
                 </div>
             </form>
         """,
@@ -281,9 +281,12 @@ def test_edit_table_auto_rows():
 def test_edit_table_post_create():
     foo_pk = TFoo.objects.create(a=1, b='asd').pk
     edit_table = EditTable(auto__model=TBar).refine_done()
+
     # language=html
     verify_html(
-        actual_html=edit_table.bind().attrs['data-add-template'],
+        actual_html=json.loads(
+            edit_table.bind(request=req('get', **{'/new_row': ''})).render_to_response().content
+        )['html'],
         # language=html
         expected_html='''
             <tr data-pk="#sentinel#">

--- a/iommi/static/css/iommi.css
+++ b/iommi/static/css/iommi.css
@@ -32,3 +32,27 @@
     float: right;
 }
 /* /advanced filter */
+
+/* EditTable */
+input[data-iommi-edit-table-delete-row-checkbox] {
+    display: none;
+}
+input[data-iommi-edit-table-delete-row-checkbox]+label {
+    display: none;
+}
+[data-iommi-edit-table-delete-with="checkbox"] button[data-iommi-edit-table-delete-row-button] {
+    display: none;
+}
+[data-iommi-edit-table-delete-with="checkbox"] input[data-iommi-edit-table-delete-row-checkbox] {
+    display: initial;
+}
+div[data-iommi-edit-table-delete-with="checkbox"] input[data-iommi-edit-table-delete-row-checkbox]+label {
+    display: initial;
+}
+[data-iommi-type="EditCells"] {
+    opacity: 1;
+}
+[data-iommi-type="EditCells"]:has(input[data-iommi-edit-table-delete-row-checkbox]:checked) {
+    opacity: 0.3;
+}
+/* /EditTable */


### PR DESCRIPTION
I'd like if you could test it first @boxed @jlubcke @viktor2097 

1) new rows are via ajax

2) delete button cleaned a bit
 plus you can now make it look:
   * either as buttons (by default) 
   * or checkboxes with `data-iommi-edit-table-delete-with="checkbox` in `EditTable.attrs`
 (both work well in `EditTable.div()` too)

3) to the select2 choices endpoint I'm sending `_choices_for_field` as a parameter, so you can tell which "row" it is called from...
later it might be good to pass `row_data` to the `choices` callable, or structurized data from the whole EditTable, I'm not sure yet, we'll discuss that later

TODO:
1) please check the `# TODO boxed/jlubcke do we need this? not used for JS anymore` - if you don't use it for css or anything else, it might be better to remove the class
2) please check/fix the docs
