### PR TITLE
Code finder

### DIFF
--- a/iommi/apps.py
+++ b/iommi/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 
+from iommi.code_finder import setup_code_finder
 from iommi.from_model import register_search_fields
 from iommi.style_bootstrap_docs import bootstrap_docs
 
@@ -56,3 +57,5 @@ class IommiConfig(AppConfig):
 
         register_factory(GenericRelation, factory=None)
         register_factory(GenericForeignKey, factory=None)
+
+        setup_code_finder()

--- a/iommi/code_finder.py
+++ b/iommi/code_finder.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from django.conf import settings
+from django.template.loader_tags import IncludeNode
+
+from iommi._web_compat import format_html
+from iommi.debug import src_debug_url_builder
+
+
+def setup_code_finder():
+    if not settings.DEBUG:
+        return
+
+    # IncludeNode monkey patch - output link to template location before each included template
+    orig_include_render = IncludeNode.render
+
+    def include_render(self, context):
+        # Get the file path and line number from the node's origin and token
+        link_html = ''
+        if hasattr(self, 'origin') and self.origin:
+            filename = self.origin.name
+            # Token has a lineno attribute that gives us the line number
+            line_number = self.token.lineno if hasattr(self, 'token') and hasattr(self.token, 'lineno') else 1
+
+            # Create a PyCharm link
+            link_html = format_html(
+                '<!-- ## iommi-code-finder-URL ## {} ## {} -->',
+                f'{Path(filename).name}:{line_number}',
+                src_debug_url_builder(filename, line_number)
+            )
+
+        result = link_html + orig_include_render(self, context)
+        return result
+
+    IncludeNode.render = include_render

--- a/iommi/menu.py
+++ b/iommi/menu.py
@@ -307,6 +307,11 @@ def get_debug_menu(**kwargs):
             attrs__onclick='window.iommi_start_pick()',
             tag='li',
         )
+        code_finder = MenuItem(
+            url='#',
+            attrs__onclick='window.insert_iommi_code_finder_links()',
+            tag='li',
+        )
         edit = MenuItem(
             display_name=lambda request, **_: (
                 'Edit vertical'


### PR DESCRIPTION
Click a new button "code finder" in the debug panel and get a little popup next to every place in the code that has an `{% include %}` tag that will take you directly to that include. See screenshot.

This could be further expanded later to handle iommi parts too. 

<img width="1302" height="845" alt="Screenshot 2025-08-29 at 10 42 40" src="https://github.com/user-attachments/assets/42872015-7a14-493c-9260-b49d86c48777" />
