### PR TITLE
capture builtin int parser's ValueError to raise a better message

### DIFF
--- a/iommi/form.py
+++ b/iommi/form.py
@@ -359,8 +359,11 @@ def float_parse(string_value: str, **_):
         raise ValueError(gettext_lazy("Could not convert string to float: {}").format(string_value))
 
 
-def int_parse(string_value, **_):
-    return int(string_value)
+def int_parse(string_value: str, **_) -> int:
+    try:
+        return int(string_value)
+    except ValueError:
+        raise ValueError(gettext_lazy("Could not convert string to int: {}").format(string_value))
 
 
 def choice_is_valid(field, parsed_data, **_):

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -817,7 +817,7 @@ def test_integer_field():
     )
 
     actual_errors = Form(fields__foo=Field.integer()).bind(request=req('get', foo=' foo  ')).fields.foo._errors
-    assert_errors_and_matches_reg_exp(actual_errors, r"invalid literal for int\(\) with base 10: 'foo'")
+    assert_errors_and_matches_reg_exp(actual_errors, r"Could not convert string to int: foo")
 
 
 def test_float_field():
@@ -1518,8 +1518,8 @@ def test_form_from_model_invalid_form():
     assert len(actual_errors) == 4
     assert {'Could not convert string to float: true'} in actual_errors
     assert {'asd is not a valid boolean value'} in actual_errors
-    assert {"invalid literal for int() with base 10: '1.1'"} in actual_errors or {
-        "invalid literal for int() with base 10: u'1.1'"
+    assert {"Could not convert string to int: 1.1"} in actual_errors or {
+        "Could not convert string to int: u1.1"
     } in actual_errors
 
 

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -4639,13 +4639,13 @@ def test_invalid_query_results_in_no_rows():
     )
 
     t_b = t.bind(request=req('get', a='not a number'))
-    assert t_b.query.form.get_errors() == {'fields': {'a': {"invalid literal for int() with base 10: 'not a number'"}}}
+    assert t_b.query.form.get_errors() == {'fields': {'a': {"Could not convert string to int: not a number"}}}
     assert not t_b.rows
 
     t_b = t.bind(request=req('get', **{'-query/query': 'a="not a number"'}))
     assert (
         t_b.query.query_error
-        == """Invalid value for filter "a": invalid literal for int() with base 10: 'not a number'"""
+        == """Invalid value for filter "a": Could not convert string to int: not a number"""
     )
     assert not t_b.rows
 

--- a/uv.lock
+++ b/uv.lock
@@ -394,7 +394,7 @@ wheels = [
 
 [[package]]
 name = "iommi"
-version = "7.26.0"
+version = "7.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
This opens up user-facing error message translation for that field
Ran make test: ok