### PR TITLE
Call Model.full_clean on form create/edit

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+Unreleased
+~~~~~~~~~~
+
+* `Form` create/edit now runs Django model validation (`Model.full_clean`), so a model's custom `clean()`/`clean_fields()` is called on save. Errors are routed to the matching field, or to the form for non-field errors. Related model instances reached through a nested `attr` (e.g. `attr='artist__name'`) are validated too.
+
+
 7.27.1 (2026-06-08)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist, ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ImproperlyConfigured, ObjectDoesNotExist, ValidationError
 from django.core.validators import EMPTY_VALUES, URLValidator, validate_email
 from django.db import (
     IntegrityError,
@@ -158,6 +158,65 @@ def validation_errors_reported_on(obj):
     except ValidationError as e:
         for msg in e.messages:
             obj.add_error(msg)
+
+
+def full_clean_object(form):
+    """
+    Run Django model validation (`Model.full_clean`) on `form.instance` and on any related
+    model instances reached through a nested `attr` (e.g. a field with `attr='artist__name'`
+    validates the `artist` instance too, since iommi saves it). Errors are routed onto the
+    matching iommi fields (or the form for non-field errors).
+
+    For each instance, model fields that aren't represented by a field on the form are
+    excluded, mirroring how Django's `ModelForm` validates the model instance. Fields that
+    iommi saves in a second phase (m2m, file fields) are also excluded: their values aren't
+    on the instance yet when creating, and iommi handles their validation separately.
+
+    Errors are routed by the model field's name (`field.model_field.name`), which is what
+    `full_clean` keys `message_dict` by, so routing works regardless of what the iommi field
+    is named. A `clean()` error keyed by a model field that has no corresponding field on the
+    form (e.g. an excluded field) falls back to the form's global errors.
+    """
+    # Group the fields by the attr prefix that points at the model instance they write to.
+    # `''` is `form.instance`; `'artist'` is `form.instance.artist`, etc.
+    fields_by_prefix = {}
+    for field in values(form.fields):
+        if field.model_field is None or field.attr is None or field.extra.get('django_related_field', False):
+            continue
+        prefix, _, _ = field.attr.rpartition('__')
+        fields_by_prefix.setdefault(prefix, {})[field.model_field.name] = field
+
+    for prefix, fields_by_model_field_name in fields_by_prefix.items():
+        if prefix:
+            try:
+                instance = getattr_path(form.instance, prefix)
+            except (ObjectDoesNotExist, AttributeError):
+                instance = None
+        else:
+            instance = form.instance
+        if instance is None:
+            continue
+
+        exclude = [
+            model_field.name
+            for model_field in (*instance._meta.fields, *instance._meta.many_to_many)
+            if model_field.name not in fields_by_model_field_name
+        ]
+        try:
+            instance.full_clean(exclude=exclude)
+        except ValidationError as e:
+            if hasattr(e, 'error_dict'):
+                for model_field_name, messages in e.message_dict.items():
+                    target = (
+                        form
+                        if model_field_name == NON_FIELD_ERRORS
+                        else fields_by_model_field_name.get(model_field_name, form)
+                    )
+                    for msg in messages:
+                        target.add_error(msg)
+            else:
+                for msg in e.messages:
+                    form.add_error(msg)
 
 
 def bool_parse(string_value, **_):
@@ -303,10 +362,7 @@ def create_or_edit_object__post_handler(*, form, is_create=None, **_):
             if not field.extra.get('django_related_field', False):
                 form.apply_field(field=field, instance=form.instance)
 
-        with validation_errors_reported_on(form):
-            form.instance.validate_unique()
-            if hasattr(form.instance, 'validate_constraints'):
-                form.instance.validate_constraints()
+        full_clean_object(form)
         if not form.is_valid():
             return
 
@@ -318,10 +374,7 @@ def create_or_edit_object__post_handler(*, form, is_create=None, **_):
     form.apply(form.instance)
 
     if not is_create:
-        with validation_errors_reported_on(form):
-            form.instance.validate_unique()
-            if hasattr(form.instance, 'validate_constraints'):
-                form.instance.validate_constraints()
+        full_clean_object(form)
         if not form.is_valid():
             return
 

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -3681,6 +3681,110 @@ def test_create_or_edit_object_validate_unique():
 
 
 @pytest.mark.django_db
+def test_create_object_calls_model_clean_global_error():
+    from tests.models import ModelWithCleanMethod
+
+    form = Form.create(auto__model=ModelWithCleanMethod)
+    bound = form.bind(request=req('post', **{'name': 'global-invalid', 'other': '', '-submit': ''}))
+    response = bound.render_to_response()
+    assert response.status_code == 200
+    assert bound.get_errors()['global'] == {'name is globally invalid'}
+    assert not ModelWithCleanMethod.objects.exists()
+
+
+@pytest.mark.django_db
+def test_create_object_calls_model_clean_field_error():
+    from tests.models import ModelWithCleanMethod
+
+    form = Form.create(auto__model=ModelWithCleanMethod)
+    bound = form.bind(request=req('post', **{'name': 'field-invalid', 'other': '', '-submit': ''}))
+    response = bound.render_to_response()
+    assert response.status_code == 200
+    assert bound.fields.name.get_errors() == {'name is field invalid'}
+    assert not ModelWithCleanMethod.objects.exists()
+
+
+@pytest.mark.django_db
+def test_create_object_passes_model_clean():
+    from tests.models import ModelWithCleanMethod
+
+    form = Form.create(auto__model=ModelWithCleanMethod)
+    response = form.bind(request=req('post', **{'name': 'fine', 'other': '', '-submit': ''})).render_to_response()
+    assert response.status_code == 302
+    assert ModelWithCleanMethod.objects.filter(name='fine').exists()
+
+
+@pytest.mark.django_db
+def test_edit_object_calls_model_clean():
+    from tests.models import ModelWithCleanMethod
+
+    instance = ModelWithCleanMethod.objects.create(name='fine')
+    form = Form.edit(auto__instance=instance)
+    bound = form.bind(request=req('post', **{'name': 'field-invalid', 'other': '', '-submit': ''}))
+    response = bound.render_to_response()
+    assert response.status_code == 200
+    assert bound.fields.name.get_errors() == {'name is field invalid'}
+    instance.refresh_from_db()
+    assert instance.name == 'fine'
+
+
+@pytest.mark.django_db
+def test_create_object_model_clean_error_routes_by_model_field_name_not_iommi_name():
+    # The iommi field is named `renamed`, but writes to (and validates) the `name` model field
+    # via `attr`. A `clean()` error keyed by the model field name `name` must still be routed to
+    # this field, not dropped or sent to the form globally.
+    from tests.models import ModelWithCleanMethod
+
+    form = Form.create(
+        auto__model=ModelWithCleanMethod,
+        auto__include=['other'],
+        fields__renamed=Field.from_model(model=ModelWithCleanMethod, model_field_name='name', attr='name'),
+    )
+    bound = form.bind(request=req('post', **{'renamed': 'field-invalid', 'other': '', '-submit': ''}))
+    response = bound.render_to_response()
+    assert response.status_code == 200
+    assert bound.fields.renamed.get_errors() == {'name is field invalid'}
+    assert bound.get_errors().get('global') is None
+    assert not ModelWithCleanMethod.objects.exists()
+
+
+@pytest.mark.django_db
+def test_edit_object_calls_model_clean_on_nested_attr_related_model():
+    # The `related_name` field writes to `related.name` (a related model) via a nested attr.
+    # That related instance is saved by iommi, so its `clean()` must run and route the error to
+    # the field.
+    from tests.models import ModelWithCleanMethod, ModelWithCleanMethodParent
+
+    related = ModelWithCleanMethod.objects.create(name='fine')
+    parent = ModelWithCleanMethodParent.objects.create(title='hi', related=related)
+
+    form = Form.edit(
+        auto__instance=parent,
+        auto__include=['title', 'related__name'],
+    )
+    bound = form.bind(request=req('post', **{'title': 'hi', 'related_name': 'field-invalid', '-submit': ''}))
+    response = bound.render_to_response()
+    assert response.status_code == 200
+    assert bound.fields.related_name.get_errors() == {'name is field invalid'}
+    related.refresh_from_db()
+    assert related.name == 'fine'
+
+
+@pytest.mark.django_db
+def test_create_object_model_clean_error_for_field_not_on_form_falls_back_to_global():
+    # `other` is not included on the form, so a `clean()` error keyed by `other` has no field to
+    # route to. It must fall back to the form's global errors rather than crash or be lost.
+    from tests.models import ModelWithCleanMethod
+
+    form = Form.create(auto__model=ModelWithCleanMethod, auto__include=['name'])
+    bound = form.bind(request=req('post', **{'name': 'other-invalid', '-submit': ''}))
+    response = bound.render_to_response()
+    assert response.status_code == 200
+    assert bound.get_errors()['global'] == {'other is field invalid'}
+    assert not ModelWithCleanMethod.objects.exists()
+
+
+@pytest.mark.django_db
 def test_create_or_edit_object_full_template_1():
     from tests.models import Foo
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -133,6 +133,27 @@ class Baz(Model):
         unique_together = ('a', 'b')
 
 
+class ModelWithCleanMethod(Model):
+    name = CharField(max_length=255, blank=True)
+    other = CharField(max_length=255, blank=True)
+
+    def clean(self):
+        from django.core.exceptions import ValidationError
+
+        super().clean()
+        if self.name == 'global-invalid':
+            raise ValidationError('name is globally invalid')
+        if self.name == 'field-invalid':
+            raise ValidationError({'name': 'name is field invalid'})
+        if self.name == 'other-invalid':
+            raise ValidationError({'other': 'other is field invalid'})
+
+
+class ModelWithCleanMethodParent(Model):
+    title = CharField(max_length=255, blank=True)
+    related = ForeignKey(ModelWithCleanMethod, on_delete=CASCADE)
+
+
 class FromModelWithInheritanceTest(Model):
     value = FloatField()
 


### PR DESCRIPTION
Run Django model validation (clean/clean_fields) when saving create/edit forms, routing errors to the matching field or the form for non-field errors. Related model instances reached through a nested attr are validated too.

Fixes #526